### PR TITLE
Update deps: prost, tonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "waves-protobuf-schemas"
-version = "1.3.2-SNAPSHOT"
+version = "1.3.3"
 edition = "2018"
 
 [dependencies]
-tonic = "0.4"
-prost = "0.7"
+tonic = "0.5"
+prost = "0.8"
 
 [build-dependencies]
-tonic-build = "0.4"
+tonic-build = "0.5"


### PR DESCRIPTION
Reason: current version of `prost` is believed to be vulnerable according to the report of `cargo audit`.
The solution is to upgrade to the latest version, which passes `cargo audit` successfully.