### PR TITLE
Update rust dependencies, add "no-recursion-limit" feature, add reexports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.4.3"
 edition = "2018"
 
 [dependencies]
-tonic = "0.5"
-prost = "0.8"
+tonic = "0.8"
+prost = "0.11"
 
 [build-dependencies]
-tonic-build = "0.5"
+tonic-build = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 tonic = "0.8"
-prost = "0.11"
+prost = { version = "0.11", features = ["no-recursion-limit"] }
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// Re-export prost & tonic crates, so that users of this library can use the same versions seamlessly
+pub use {prost, tonic};
+
 pub mod waves {
     tonic::include_proto!("waves");
 


### PR DESCRIPTION
This pull request is about the following:
- [x] Update Rust dependencies (prost & tonic) to the latest versions
- [x] Add "no-recursion-limit" feature to prost dependency because it is requires to parse Waves Mainnet blockchain
- [x] Add reexports of the prost & tonic crates for the convenience of the users of this library