### PR TITLE
NODE-2599 Public key in AccountScriptInfo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.wavesplatform</groupId>
     <artifactId>protobuf-schemas</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.5</version>
+    <version>1.4.6-SNAPSHOT</version>
 
     <name>Waves Node protobuf classes</name>
     <description>Waves Node protobuf java classes</description>

--- a/proto/waves/node/grpc/accounts_api.proto
+++ b/proto/waves/node/grpc/accounts_api.proto
@@ -11,7 +11,7 @@ import "google/protobuf/wrappers.proto";
 
 service AccountsApi {
     rpc GetBalances (BalancesRequest) returns (stream BalanceResponse);
-    rpc GetScript (AccountRequest) returns (ScriptData);
+    rpc GetScript (AccountRequest) returns (ScriptResponse);
     rpc GetActiveLeases (AccountRequest) returns (stream LeaseResponse);
     rpc GetDataEntries (DataRequest) returns (stream DataEntryResponse);
     rpc ResolveAlias (google.protobuf.StringValue) returns (google.protobuf.BytesValue);
@@ -56,6 +56,13 @@ message ScriptData {
     bytes script_bytes = 1;
     string script_text = 2;
     int64 complexity = 3;
+}
+
+message ScriptResponse {
+    bytes script_bytes = 1;
+    string script_text = 2;
+    int64 complexity = 3;
+    bytes public_key = 4;
 }
 
 message LeaseResponse {


### PR DESCRIPTION
`AccountsApi/GetScript` returns `ScriptResponse` instead of `ScriptData`. 
It has same fields for compatibility reasons with one extra: `public_key` - a public key of the account.